### PR TITLE
fix: CI 변수 추가

### DIFF
--- a/.github/workflows/ci-develop-main.yml
+++ b/.github/workflows/ci-develop-main.yml
@@ -11,6 +11,9 @@ jobs:
     name: Run tests & build
     runs-on: ubuntu-latest
 
+    env:
+      CI: false  # CI 변수를 명시적으로 false로 설정
+      
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
- 배포 시 환경 변수 오류로 인하여 ci-develop-main.yml 파일 env에 CI 변수 추가, false로 설정 
close #37 